### PR TITLE
Fix duplicate column error in import_MSF_v2

### DIFF
--- a/src/ImportCRSP.jl
+++ b/src/ImportCRSP.jl
@@ -305,7 +305,7 @@ function import_MSF_v2(wrds_conn::Connection;
     msf_v2_columns = _get_postgres_columns("crsp", "msf_v2"; wrds_conn=wrds_conn) |> sort
     col_select = ["permno", "hdrcusip", "mthcaldt", "mthprc", "mthret", "mthcap", "shrout",
         "mthretx", "mthprevcap", "mthprevprc", "permco"]
-    col_query = @p vcat(col_select, variables) |> 
+    col_query = @p vcat(col_select, variables) |> unique |>
         uppercase.(__) |> filter(!isempty) |> filter(_ ∈ msf_v2_columns)
     # note that selecting all variables to download here is a lot slower than with msf_v1 because of the many more variables ...
 


### PR DESCRIPTION
Passing a variable in `variables` that already exists in the default `col_select`
(e.g. `"hdrcusip"`) causes a `Duplicate variable names` error because the SQL
SELECT contains the same column twice.

This matters because some default columns (like `hdrcusip`) are queried but
dropped from the final output by `var_select`. The only way for a user to
retain them is to pass them in `variables`, but that currently errors due to
the duplicate.

Fix: add `unique` to the pipeline to deduplicate before building the query.